### PR TITLE
Fix start node flow behavior

### DIFF
--- a/client/src/components/CustomNodes.tsx
+++ b/client/src/components/CustomNodes.tsx
@@ -29,7 +29,9 @@ export function StartNode({ data, selected }: CustomNodeProps) {
         </div>
         <div className="w-3 h-3 bg-[hsl(var(--cyber-green))] rounded-full animate-pulse"></div>
       </div>
-      <div className="text-sm text-gray-300">Flow entry point</div>
+      <div className="text-sm text-gray-300 italic">
+        {data.text || "Click to set welcome message..."}
+      </div>
       
       <Handle
         type="source"

--- a/client/src/components/PropertiesPanel.tsx
+++ b/client/src/components/PropertiesPanel.tsx
@@ -108,20 +108,24 @@ export function PropertiesPanel({
           </div>
           
           <div className="space-y-4">
-            {selectedNode.type !== "start" && (
-              <div>
-                <Label className="text-sm text-gray-400 mb-2">
-                  {selectedNode.type === "message" ? "Message Text" : "Question Text"}
-                </Label>
-                <Textarea
-                  value={localData.text || ""}
-                  onChange={(e) => handleDataChange("text", e.target.value)}
-                  placeholder={`Enter your ${selectedNode.type}...`}
-                  className="bg-[hsl(var(--cyber-dark),0.5)] border-[hsl(var(--cyber-pink),0.5)] text-white placeholder-gray-500 focus:border-[hsl(var(--cyber-pink))] resize-none"
-                  rows={3}
-                />
-              </div>
-            )}
+            <div>
+              <Label className="text-sm text-gray-400 mb-2">
+                {selectedNode.type === "start"
+                  ? "Welcome Message"
+                  : selectedNode.type === "message"
+                  ? "Message Text"
+                  : "Question Text"}
+              </Label>
+              <Textarea
+                value={localData.text || ""}
+                onChange={(e) => handleDataChange("text", e.target.value)}
+                placeholder={`Enter your ${
+                  selectedNode.type === "start" ? "welcome message" : selectedNode.type
+                }...`}
+                className="bg-[hsl(var(--cyber-dark),0.5)] border-[hsl(var(--cyber-pink),0.5)] text-white placeholder-gray-500 focus:border-[hsl(var(--cyber-pink))] resize-none"
+                rows={3}
+              />
+            </div>
             
             {selectedNode.type === "question" && (
               <>

--- a/client/src/pages/flow-builder.tsx
+++ b/client/src/pages/flow-builder.tsx
@@ -22,6 +22,7 @@ export default function FlowBuilder() {
   const [isChatbotVisible, setIsChatbotVisible] = useState(false);
   const [lastSaved, setLastSaved] = useState<string>("Never");
   const [draggedNodeType, setDraggedNodeType] = useState<string | null>(null);
+  const [welcomePromptShown, setWelcomePromptShown] = useState(false);
 
   // Load flow data
   const { data: flowData, isLoading } = useQuery({
@@ -40,6 +41,22 @@ export default function FlowBuilder() {
       setEdges(flowData.edges);
     }
   }, [flowData]);
+
+  // Prompt for welcome message on first load if start node lacks text
+  useEffect(() => {
+    if (!welcomePromptShown && nodes.length > 0) {
+      const startNode = nodes.find((n) => n.type === "start");
+      if (startNode && !startNode.data.text) {
+        const msg = window.prompt("Enter a welcome message for this flow:", "");
+        if (msg) {
+          handleUpdateNode(startNode.id, { text: msg });
+        }
+      }
+      if (startNode) {
+        setWelcomePromptShown(true);
+      }
+    }
+  }, [nodes, welcomePromptShown, handleUpdateNode]);
 
   // Save flow mutation
   const saveFlowMutation = useMutation({
@@ -102,6 +119,13 @@ export default function FlowBuilder() {
           text: nodeType === "start" ? undefined : `Enter your ${nodeType}...`,
         },
       };
+
+      if (nodeType === "start") {
+        const msg = window.prompt("Enter a welcome message for this flow:", "");
+        if (msg) {
+          newNode.data.text = msg;
+        }
+      }
 
       setNodes(prev => [...prev, newNode]);
     },

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -18,7 +18,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
             {
               id: "start-node-1",
               type: "start",
-              position: { x: 100, y: 50 },
+              position: { x: 0, y: 0 },
               data: {}
             }
           ],


### PR DESCRIPTION
## Summary
- display welcome message in Start block
- allow editing any block text including Start node
- prompt for welcome message on load or when dropping Start node
- adjust Start node default position

## Testing
- `npm run check` *(fails: Cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_683b5437e3a8832494e8ed1a45ae24b7